### PR TITLE
Fixed bcrypt hashed password not converted to string

### DIFF
--- a/backend/src/helpers/encrypt.ts
+++ b/backend/src/helpers/encrypt.ts
@@ -14,6 +14,7 @@ const verifyPassword = async (password: string, hash: string): Promise<boolean> 
 };
 
 export const hashPassword = async (password: string) => {
-  return await hash(password);
+  const hashedPassword = await hash(password);
+  return String(hashedPassword);
 };
 


### PR DESCRIPTION
bcrypt hashed password function was returning a number when we needed a string.