### PR TITLE
broker and uuid updates

### DIFF
--- a/backend/src/helpers/sourceHelper.ts
+++ b/backend/src/helpers/sourceHelper.ts
@@ -1,9 +1,7 @@
 import { PGSourceDetails, DebeziumConnector, PGDetailsNoPW } from "../types/sourceTypes"
-import shortUuid from 'short-uuid';
+import { createUUID } from './uuid';
 import { query } from '../database/pg';
 import { hashPassword } from "./encrypt";
-
-const VALID_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789_';
 
 export const getConfigData = (sourceDetails: PGSourceDetails): DebeziumConnector => {
   return {
@@ -19,7 +17,7 @@ export const getConfigData = (sourceDetails: PGSourceDetails): DebeziumConnector
       "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
       "table.include.list": "public.outbox",
       "tombstone.on.delete": "false",
-      "slot.name": `tumbleweed_${shortUuid(VALID_CHARS).generate()}`,
+      "slot.name": `tumbleweed_${createUUID}`,
       "transforms": "outbox",
       "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
       "transforms.outbox.table.fields.additional.placement": "type:envelope:type",

--- a/backend/src/helpers/uuid.ts
+++ b/backend/src/helpers/uuid.ts
@@ -1,0 +1,6 @@
+import shortUuid from 'short-uuid';
+
+export const createUUID = () => {
+  const VALID_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789_';
+  return shortUuid(VALID_CHARS).generate();
+};

--- a/backend/src/kafka/kafkaClientSSEConnect.ts
+++ b/backend/src/kafka/kafkaClientSSEConnect.ts
@@ -1,18 +1,20 @@
 import { Request, Response } from 'express';
-import dotenv from 'dotenv';
 import { Kafka, Consumer, EachMessagePayload } from 'kafkajs';
-dotenv.config();
+import { getKafkaBrokerEndpoints } from '../kafka/kafkaAdmin';
+import { createUUID } from '../helpers/uuid';
 
-const KafkaBrokerEndpointsString = process.env.KAFKA_BROKER_ENDPOINTS;
+let kafka: Kafka;
 
-if (!KafkaBrokerEndpointsString) {
-  throw new Error("Kafka broker endpoints are not defined");
-}
-const KafkaBrokerEndpoints: string[] = JSON.parse(KafkaBrokerEndpointsString);
+const initializeKafka = async () => {
+  const brokers = await getKafkaBrokerEndpoints();
+  kafka = new Kafka({
+    clientId: createUUID(),
+    brokers,
+  });
+};
 
-const kafka = new Kafka({
-  clientId: 'sse-test-client',
-  brokers: KafkaBrokerEndpoints,
+initializeKafka().catch(error => {
+  console.error(`Failed to initialize Kafka: ${error}`);
 });
 
 export const createConsumer = async (group_id: string, topics: string[]) => {


### PR DESCRIPTION
- dynamically fetch broker endpoints from kafka
Now we don't have to hardcode or use those in an .env
- generate uuid for clientID upon kafka init
Co-authored-by: Cruz <102073996+archzedzenrun@users.noreply.github.com>