### PR TITLE
Refactor:

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,34 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/.next
+**/.cache
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/charts
+**/docker-compose*
+**/compose.y*ml
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+**/build
+**/dist
+LICENSE
+README.md

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,15 +12,15 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-app.use(express.static(path.join(__dirname, '..', 'dist')));
+// app.use(express.static(path.join(__dirname, '..', 'dist')));
 app.use('/api/sources', sourceRouter);
 app.use('/api/consumers', consumerRouter);
 app.use('/api/topics', topicRouter);
 app.use('/tumbleweed', kafkaRouter);
 app.use(errorHandler);
 
-app.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'dist', 'index.html'));
-});
+// app.get('*', (req, res) => {
+//   res.sendFile(path.join(__dirname, '..', 'dist', 'index.html'));
+// });
 
 export default app;

--- a/backend/src/routes/sourceRoutes.ts
+++ b/backend/src/routes/sourceRoutes.ts
@@ -1,6 +1,15 @@
 import axios from 'axios';
 import express from 'express';
-import { getConfigData, postConfigDataToDB, getAllConnectors, deleteConnectorByName, getConnectorByName, createOutboxTableInSource, deleteReplicationSlot, getConnectorWithSlotNameandPW } from '../helpers/sourceHelper';
+import {
+  getConfigData,
+  postConfigDataToDB,
+  getAllConnectors,
+  deleteConnectorByName,
+  getConnectorByName,
+  createOutboxTableInSource,
+  deleteReplicationSlot,
+  getConnectorWithSlotNameandPW
+} from '../helpers/sourceHelper';
 import { formatDateForFrontend } from '../helpers/consumerHelper';
 import { PGDetailsNoPW, PGCredentials, PGSourceDetailsWithSlotName } from '../types/sourceTypes';
 import { validateSourceDetails, validateDBCredentials } from '../helpers/validation';
@@ -104,7 +113,7 @@ router.post('/new_source', async (req, res, next) => {
 
     res.status(201).send({
       message: 'Connector created',
-      data: newConnector,
+      data: {...newConnector, date_created: formatDateForFrontend(new Date().toString())}
     });
   } catch (error) {
     console.error(`There was an error adding a new connector: ${error}`);

--- a/frontend/src/components/Source.tsx
+++ b/frontend/src/components/Source.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction } from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import { SourceData } from "../types/types"
 
 import {
@@ -19,7 +19,7 @@ interface SourceProps {
   openSource: boolean;
   handleDeleteSource: () => void;
   sourceData: SourceData | null;
-  setSelectedSource: Dispath<SourceData | null>;
+  setSelectedSource: Dispatch<React.SetStateAction<SourceData | null>>;
 }
 
 const style = {

--- a/frontend/src/components/SourceForm.tsx
+++ b/frontend/src/components/SourceForm.tsx
@@ -67,7 +67,7 @@ export const SourceForm = ({
 
       setErrors({});
       const res = await createSource(sourceData);
-      setSources((prevSources) => prevSources.concat(res.data.name));
+      setSources((prevSources) => prevSources.concat(res.data));
       setSuccess(true);
       setSuccessMsg("Source created successfully!");
       setOpenSourceForm(false);

--- a/frontend/src/components/Sources.tsx
+++ b/frontend/src/components/Sources.tsx
@@ -113,26 +113,8 @@ export const Sources = ({ setLoading }: SourcesProps) => {
         )}
         <div id="sourcelist">
           <h1>Source List</h1>
-          {sources.length === 0 ? (<>
-            <Box sx={{ mt: 2 }}>
-                <Button
-                  variant="contained"
-                  className="connectionButton"
-                  onClick={() => setOpenSourceForm(true)}
-                  sx={{
-                    fontFamily: "Montserrat",
-                    fontWeight: 400,
-                    borderRadius: '30px',
-                    backgroundColor: '#70AF85',
-                    '&:hover': {
-                      backgroundColor: '#F58B33'
-                    },
-                  }}
-                >
-                  Create New Source
-                </Button>
-              </Box>
-          </>) : (<>
+          {sources.length > 0 && (
+          <>
             <TableContainer
                 component={Paper}
                 sx={{
@@ -142,88 +124,90 @@ export const Sources = ({ setLoading }: SourcesProps) => {
                   boxSizing: 'border-box'
                 }}
               >
-                <Table sx={{ minWidth: 650, tableLayout: 'fixed' }} size="small" aria-label="source list table">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell sx={{ fontFamily: "Montserrat", fontWeight: 700, position: 'sticky', left: 0, backgroundColor: '#fff', zIndex: 1 }}>
-                        Name
-                      </TableCell>
-                      <TableCell sx={{ fontFamily: "Montserrat", fontWeight: 700 }}>Date Added</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody sx={{ marginRight: '100px' }}>
-                    {currentSources.map(source => (
-                      <TableRow key={source.name}>
-                        <TableCell sx={{
+              <Table sx={{ minWidth: 650, tableLayout: 'fixed' }} size="small" aria-label="source list table">
+                <TableHead>
+                  <TableRow>
+                    <TableCell sx={{ fontFamily: "Montserrat", fontWeight: 700, position: 'sticky', left: 0, backgroundColor: '#fff', zIndex: 1 }}>
+                      Name
+                    </TableCell>
+                    <TableCell sx={{ fontFamily: "Montserrat", fontWeight: 700 }}>Date Added</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody sx={{ marginRight: '100px' }}>
+                  {currentSources.map(source => (
+                    <TableRow key={source.name}>
+                      <TableCell
+                        sx={{
                           fontSize: '0.875rem',
                           position: 'sticky',
                           left: 0,
                           backgroundColor: '#fff',
                           zIndex: 1,
-                        }}>
-                          <Link
-                            className="link"
-                            onClick={(e) => {
-                              e.preventDefault();
-                              setSelectedSource(source);
-                              setOpenSource(true);
-                            } }
-                            to={''}
-                          >
-                            {source.name}
-                          </Link>
-                        </TableCell>
-                        <TableCell sx={{
-                          fontFamily: "Montserrat",
-                          fontWeight: 400,
-                          fontSize: '0.875rem'
                         }}
+                      >
+                        <Link
+                          className="link"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            setSelectedSource(source);
+                            setOpenSource(true);
+                          } }
+                          to={''}
                         >
-                          {source.date_created}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </TableContainer>
-          
-              <Box display="flex" alignItems="center" justifyContent="space-between" sx={{ mr: 9.5, marginLeft: "50px" }}>
-                <Box sx={{ mt: 2 }}>
-                  <Button
-                    variant="contained"
-                    className="connectionButton"
-                    onClick={() => setOpenSourceForm(true)}
-                    sx={{
-                    fontFamily: "Montserrat",
-                    fontWeight: 400,
-                    borderRadius: '30px',
-                    backgroundColor: '#70AF85',
-                    '&:hover': {
-                      backgroundColor: '#F58B33'
-                    },
-                  }}
-                >
-                  Create New Source
-                </Button>
-              </Box>
-                <TablePagination
-                  rowsPerPageOptions={[5, 10, 25]}
-                  component="div"
-                  count={sources.length}
-                  rowsPerPage={rowsPerPage}
-                  page={page}
-                  onPageChange={handleChangePage}
-                  onRowsPerPageChange={handleChangeRowsPerPage}
-                  sx={{
-                    '& .MuiTablePagination-toolbar': { minHeight: '36px' },
-                    '& .MuiTablePagination-selectLabel, .MuiTablePagination-input, .MuiTablePagination-displayedRows': {
-                      fontSize: '0.75rem', fontFamily: "Montserrat", fontWeight: 400
-                    },
-                  }}
-                />
-              </Box>
-            </>
-          )}
+                          {source.name}
+                        </Link>
+                      </TableCell>
+                      <TableCell sx={{
+                        fontFamily: "Montserrat",
+                        fontWeight: 400,
+                        fontSize: '0.875rem'
+                      }}
+                      >
+                        {source.date_created}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+            <Box display="flex" alignItems="center" justifyContent="right" sx={{ mr: 9.5, marginLeft: "50px" }}>
+              <TablePagination
+                rowsPerPageOptions={[5, 10, 25]}
+                component="div"
+                count={sources.length}
+                rowsPerPage={rowsPerPage}
+                page={page}
+                onPageChange={handleChangePage}
+                onRowsPerPageChange={handleChangeRowsPerPage}
+                sx={{
+                  '& .MuiTablePagination-toolbar': { minHeight: '36px' },
+                  '& .MuiTablePagination-selectLabel, .MuiTablePagination-input, .MuiTablePagination-displayedRows': {
+                    fontSize: '0.75rem', fontFamily: "Montserrat", fontWeight: 400
+                  },
+                }}
+              />
+            </Box>
+          </>
+        )}
+          <Box sx={{ mt: 2 }}>
+              <Button
+                variant="contained"
+                className="connectionButton"
+                onClick={() => setOpenSourceForm(true)}
+                sx={{
+                  marginLeft: '50px',
+                  fontFamily: "Montserrat",
+                  fontWeight: 400,
+                  borderRadius: '30px',
+                  backgroundColor: '#70AF85',
+                  '&:hover': {
+                    backgroundColor: '#F58B33'
+                  },
+              }}
+              >
+                Create New Source
+              </Button>
+            </Box>
         </div>
         {selectedSource && openSource &&
           <>


### PR DESCRIPTION
- Fixed the issue of the sources page not re-rendering when a new source is created

- The sources page now displays no table when there are no sources

- Changed the placement of the `Create Source` button, it is now placed outside `TableContainer` so that it renders properly when there are no sources.

- Added a date key-val pair to be sent back with the response data when creating a new source. This allows the `Date Added` field to be properly shown when a new source is created and the table re-renders. Without it, the field does not appear until a refresh is done. This is more consistent with the data that is sent back when a query is made to the `sources` table in the database.

- There is an issue with the point above, the date is inconsistent with what is being stored in the database. I'm assuming it has to do with the timezone. We'll need to explore this a little deeper to fix.

- Added a `VITE_API_URL` variable to the `.env` file, the variable `VITE_BASE_URL` was not consistent with what was being used in the frontend routes.